### PR TITLE
Fix Read Timeout Error #25

### DIFF
--- a/dxm/lib/DxEngine/DxMaskingEngine.py
+++ b/dxm/lib/DxEngine/DxMaskingEngine.py
@@ -504,7 +504,7 @@ class DxMaskingEngine(object):
         Return timeout for query
         Tuple (connect_timeout, read_timeout)
         """
-        return (5, 15)
+        return (5, 60)
         """    enginelist = get_list_of_engines(p_engine)
 
     if enginelist is None:


### PR DESCRIPTION
# Context
The timeout occurs when an operation is performed on a ruleset with hundreds or thousands of tables.

# Problem:
Read timeout issue #25 

# Solution:
Increased the read timeout from 15 seconds to 60 seconds